### PR TITLE
send a --boundary line before the first frame

### DIFF
--- a/ESP32-CAM-Video-Streaming/ESP32-CAM-Video-Streaming.ino
+++ b/ESP32-CAM-Video-Streaming/ESP32-CAM-Video-Streaming.ino
@@ -135,6 +135,11 @@ static esp_err_t stream_handler(httpd_req_t *req){
     return res;
   }
 
+  res = httpd_resp_send_chunk(req, _STREAM_BOUNDARY, strlen(_STREAM_BOUNDARY));
+  if(res != ESP_OK){
+    return res;
+  }
+
   while(true){
     fb = esp_camera_fb_get();
     if (!fb) {


### PR DESCRIPTION
gst multipartdemux (from gst 1.16.2) errors on the stream without this line; works with it. Chrome will display the stream correctly either way.