### PR TITLE
fix: use of deprecated camera_config_t members

### DIFF
--- a/ESP32-CAM-Change-Settings/ESP32-CAM-Change-Settings.ino
+++ b/ESP32-CAM-Change-Settings/ESP32-CAM-Change-Settings.ino
@@ -76,8 +76,8 @@ void configInitCamera(){
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-HTTP-POST-Image/ESP32-CAM-HTTP-POST-Image.ino
+++ b/ESP32-CAM-HTTP-POST-Image/ESP32-CAM-HTTP-POST-Image.ino
@@ -81,8 +81,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-HTTP-POST-Image/ESP32-CAM-HTTPS-POST-Image.ino
+++ b/ESP32-CAM-HTTP-POST-Image/ESP32-CAM-HTTPS-POST-Image.ino
@@ -83,8 +83,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-OpenCV-js/ESP32-CAM-OpenCV-js.ino
+++ b/ESP32-CAM-OpenCV-js/ESP32-CAM-OpenCV-js.ino
@@ -118,8 +118,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-PIR-Photo-Capture/ESP32-CAM-PIR-Photo-Capture.ino
+++ b/ESP32-CAM-PIR-Photo-Capture/ESP32-CAM-PIR-Photo-Capture.ino
@@ -67,8 +67,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-Take-Photo-Date-Time-MicroSD-Card/ESP32-CAM-Take-Photo-Date-Time-MicroSD-Card.ino
+++ b/ESP32-CAM-Take-Photo-Date-Time-MicroSD-Card/ESP32-CAM-Take-Photo-Date-Time-MicroSD-Card.ino
@@ -60,8 +60,8 @@ void configInitCamera(){
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-Take-Photo-Save-MicroSD-Card/ESP32-CAM-Take-Photo-Save-MicroSD-Card.ino
+++ b/ESP32-CAM-Take-Photo-Save-MicroSD-Card/ESP32-CAM-Take-Photo-Save-MicroSD-Card.ino
@@ -68,8 +68,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-Take-Photo-and-Display-Web-Server/ESP32-CAM-Take-Photo-and-Display-Web-Server.ino
+++ b/ESP32-CAM-Take-Photo-and-Display-Web-Server/ESP32-CAM-Take-Photo-and-Display-Web-Server.ino
@@ -136,8 +136,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-Take-Send-Photo-Telegram/ESP32-CAM-Take-Send-Photo-Telegram.ino
+++ b/ESP32-CAM-Take-Send-Photo-Telegram/ESP32-CAM-Take-Send-Photo-Telegram.ino
@@ -77,8 +77,8 @@ void configInitCamera(){
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-Video-Streaming/ESP32-CAM-Access-Point-AP-Video-Streaming.ino
+++ b/ESP32-CAM-Video-Streaming/ESP32-CAM-Access-Point-AP-Video-Streaming.ino
@@ -240,8 +240,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/ESP32-CAM-Video-Streaming/ESP32-CAM-Video-Streaming.ino
+++ b/ESP32-CAM-Video-Streaming/ESP32-CAM-Video-Streaming.ino
@@ -220,8 +220,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/TTGO-T-Journal-ESP32-Camera/TTGO-T-Journal-ESP32-Camera-Take-Photo-Web-Server.ino
+++ b/TTGO-T-Journal-ESP32-Camera/TTGO-T-Journal-ESP32-Camera-Take-Photo-Web-Server.ino
@@ -160,8 +160,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;

--- a/TTGO-T-Journal-ESP32-Camera/TTGO-T-Journal-ESP32-Camera-Video-Streaming-Web-Server.ino
+++ b/TTGO-T-Journal-ESP32-Camera/TTGO-T-Journal-ESP32-Camera-Video-Streaming-Web-Server.ino
@@ -157,8 +157,8 @@ void setup() {
   config.pin_pclk = PCLK_GPIO_NUM;
   config.pin_vsync = VSYNC_GPIO_NUM;
   config.pin_href = HREF_GPIO_NUM;
-  config.pin_sscb_sda = SIOD_GPIO_NUM;
-  config.pin_sscb_scl = SIOC_GPIO_NUM;
+  config.pin_sccb_sda = SIOD_GPIO_NUM;
+  config.pin_sccb_scl = SIOC_GPIO_NUM;
   config.pin_pwdn = PWDN_GPIO_NUM;
   config.pin_reset = RESET_GPIO_NUM;
   config.xclk_freq_hz = 20000000;


### PR DESCRIPTION
The following warnings were issued during compilation:
- 'camera_config_t::<unnamed union>::pin_sscb_sda' is deprecated: please use pin_sccb_sda instead [-Wdeprecated-declarations] config.pin_sscb_sda = SIOD_GPIO_NUM;
- 'camera_config_t::<unnamed union>::pin_sscb_scl' is deprecated: please use pin_sccb_scl instead [-Wdeprecated-declarations] config.pin_sscb_scl = SIOC_GPIO_NUM;

This commit updates the variable names to eliminates these warnings.